### PR TITLE
Correct score name in fbeta_score_evaluator docstring

### DIFF
--- a/src/fklearn/validation/evaluators.py
+++ b/src/fklearn/validation/evaluators.py
@@ -168,7 +168,7 @@ def fbeta_score_evaluator(test_data: pd.DataFrame,
                           target_column: str = "target",
                           eval_name: str = None) -> EvalReturnType:
     """
-    Computes the recall score, given true label and prediction scores.
+    Computes the F-beta score, given true label and prediction scores.
 
     Parameters
     ----------


### PR DESCRIPTION
### Status
**READY**

### Background context
Copy & paste typo discovered in API docs of validation.evaluators.fbeta_score_evaluator 

### Description of the changes proposed in the pull request
Typo fixed to correct score name in fbeta_score_evaluator docstring. Rest of docstring LGTM.